### PR TITLE
Update jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,6 +3,8 @@
 		"target": "es2017",
 		"module": "commonjs",
 		"baseUrl": "./src",
+                "noImplicitAny": true,
+		"esModuleInterop": true,
 		"checkJs": true
 	}
 }


### PR DESCRIPTION
"noImplicitAny": true- This option tells the compiler to report an error when it encounters an implicit any type. This can help to improve the type safety of your code. To enable this option, add the following to your compilerOptions

"esModuleInterop": true - This option tells the compiler to automatically import and export ES modules when using CommonJS modules. This can help to make your code more compatible with both ES modules and CommonJS modules. To enable this option, add the following to your compilerOptions

Added these two. Hope this helps. Thanks!
